### PR TITLE
Android & iOS build file updates

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,8 +1,9 @@
 apply plugin: 'com.android.library'
 
 android {
+    namespace "com.remobile.cordova"
     compileSdkVersion 23
-    buildToolsVersion "23.0.1"
+    buildToolsVersion "30.0.3"
 
     defaultConfig {
         minSdkVersion 16
@@ -19,7 +20,7 @@ android {
 }
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:23.0.1'
-    compile 'com.facebook.react:react-native:+'
+    implementation fileTree(dir: 'libs', include: ['*.jar'])
+    implementation 'com.android.support:appcompat-v7:23.0.1'
+    implementation 'com.facebook.react:react-native:+'
 }

--- a/ios/RCTCordova.podspec
+++ b/ios/RCTCordova.podspec
@@ -1,0 +1,20 @@
+require 'json'
+
+package = JSON.parse(File.read(File.join(__dir__, '../package.json')))
+
+Pod::Spec.new do |s|
+  s.name         = "RCTCordova"
+  s.version      = package['version']
+  s.summary      = package['description']
+
+  s.homepage     = package['homepage']
+  s.authors      = package['author']
+  s.license      = package['license']
+  s.platform     = :ios, "9.0"
+
+  s.source         = { :git => '' }
+  s.source_files   = '**/*.{h,m}'
+  s.preserve_paths = '**/*.{h,m}'
+
+  s.dependency 'React-Core'
+end 


### PR DESCRIPTION
- Add podspec file for iOS
- Update Android build.gradle to support newer build tools

These allow removing the npm postinstall hack https://github.com/IndoorAtlas/cordova-plugin/blob/react-native/package.json#L20 which currently only works with yarn install, but not with npm install (and probably not with Windows).
